### PR TITLE
More specific R.methodsS3 & R.oo imports - needed soon

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,7 @@
 # ---- IMPORTS ----
 # Packages to be imported
-import("R.methodsS3","R.oo")
+importFrom("R.methodsS3", "setMethodS3")
+importFrom("R.oo", "setConstructorS3", "extend", "Object")
 
 # Object that must exported explicitly
 


### PR DESCRIPTION
Hi, I need to do some updates to R.oo, and later R.methodsS3, that _eventually_ will introduce WARNINGs for your package of the kind:
```
Found the following significant warnings:
  Warning: replacing previous import ‘R.methodsS3::throw’ by ‘R.oo::throw’ when loading ‘cgdsr’
```
This PR prevents this by simply using specific `importFrom()`:s rather than `import()` which throws a too big of a net.
